### PR TITLE
perf(continew-starter-web): ⚡ 优化文件工具类下载文件逻辑，减少堆内存占用

### DIFF
--- a/continew-starter-web/src/main/java/top/continew/starter/web/util/FileUploadUtils.java
+++ b/continew-starter-web/src/main/java/top/continew/starter/web/util/FileUploadUtils.java
@@ -18,7 +18,6 @@ package top.continew.starter.web.util;
 
 import cn.hutool.core.date.DatePattern;
 import cn.hutool.core.date.DateUtil;
-import cn.hutool.core.io.IoUtil;
 import cn.hutool.core.io.file.FileNameUtil;
 import cn.hutool.core.util.IdUtil;
 import cn.hutool.core.util.URLUtil;
@@ -104,11 +103,11 @@ public class FileUploadUtils {
     public static void download(HttpServletResponse response,
                                 InputStream inputStream,
                                 String fileName) throws IOException {
-        byte[] bytes = IoUtil.readBytes(inputStream);
         response.setCharacterEncoding(StandardCharsets.UTF_8.toString());
         response.setContentType(MediaType.APPLICATION_OCTET_STREAM_VALUE);
-        response.setContentLength(bytes.length);
         response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + URLUtil.encode(fileName));
-        IoUtil.write(response.getOutputStream(), true, bytes);
+        try (inputStream; var outputStream = response.getOutputStream()) {
+            response.setContentLengthLong(inputStream.transferTo(outputStream));
+        }
     }
 }


### PR DESCRIPTION
<!--
  非常感谢您的 PR！在提交之前，请务必确保您 PR 的代码经过了完整测试，并且通过了代码规范检查。
-->

<!-- 在 [] 中输入 x 来勾选) -->

## PR 类型

<!-- 您的 PR 引入了哪种类型的变更？ -->
<!-- 只支持选择一种类型，如果有多种类型，可以在更新日志中增加 “类型” 列。 -->

- [ ] 新 feature
- [ ] Bug 修复
- [ ] 功能增强
- [ ] 文档变更
- [ ] 代码样式变更
- [ ] 重构
- [x] 性能改进
- [ ] 单元测试
- [ ] CI/CD
- [ ] 其他

## PR 目的

使用文件工具类`FileUploadUtils`下载大文件，或者并发下载文件时，减少堆内存占用。

## 解决方案

将一次性读取文件到byte数组，修改为文件流的方式。

## PR 测试

`DemoController`启动服务后测试
![image](https://github.com/user-attachments/assets/475abe13-3838-44b6-92f2-c150956a05ac)

## Changelog

| 模块  | Changelog | Related issues |
|-----|-----------| -------------- |
|     |           |                |

<!-- 如果有多种类型的变更，可以在变更日志表中增加 “类型” 列，该列的值与上方 “PR 类型” 相同。 -->
<!-- Related issues 格式为 Closes #<issue号>，或者 Fixes #<issue号>，或者 Resolves #<issue号>。 -->

## 其他信息

<!-- 请描述一下还有哪些注意事项。例如：如果引入了一个不向下兼容的变更，请描述其影响。 -->

## 提交前确认

- [x] PR 代码经过了完整测试，并且通过了代码规范检查
- [ ] 已经完整填写 Changelog，并链接到了相关 issues
- [x] PR 代码将要提交到 dev 分支